### PR TITLE
Ignore dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,21 +4,16 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-      time: "04:00" # UTC
-    #labels:
-    #  - "domain: deps"
     commit-message:
-      prefix: "chore(deps)"
+      prefix: "security"
     reviewers:
       - "bruceg"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 0
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
     reviewers:
       - "bruceg"
-    #labels:
-    #  - "domain: ci"
     commit-message:
-      prefix: "chore(ci)"
+      prefix: "chore"


### PR DESCRIPTION
This sets dependabot to only open security updates according to [this](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates).