### PR TITLE
Auto-apply dep updates in a group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,14 @@ updates:
     schedule:
       interval: "daily"
     commit-message:
-      prefix: "security"
+      prefix: "deps"
     reviewers:
       - "bruceg"
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 10
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
This is a partial revert of #47. Dependabot will now manage all version updates as well, but will group them daily.