### PR TITLE
bug: Fix handling of non-file copyright locations

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -443,7 +443,7 @@ fn lookup_copyrights(package: &mut Package) -> Result<String> {
     }
     for location in COPYRIGHT_LOCATIONS {
         let path = source_path.join(location);
-        if path.exists() {
+        if path.is_file() {
             if let Some(copyright) = lookup_copyright(&path)? {
                 return Ok(copyright);
             }


### PR DESCRIPTION
If a dependency has a directory named the same as one of the copyright locations, the license tool would try to open it as a file and exit with an error because the tool was checking if the name existed and not if it was a file. This change fixes the check to ensure the name exists and is a file.