### PR TITLE
Add support for workspaces.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 /target
-/.vscode


### PR DESCRIPTION
## Context

Prior to this PR, the code assumed it was running within the context of a top-level package (i.e. Observability Pipelines Worker, or Vector) and operated under that assumption. This breaks when running under a "pure" workspace, however:

```
thread 'main' panicked at /home/toby/.cargo/registry/src/index.crates.io-6f17d22bba15001f/dd-rust-license-tool-1.0.2/src/main.rs:231:29:
called `Option::unwrap()` on a `None` value
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
make: *** [Makefile:105: check-licenses] Error 101
```

The line referred to is one where the tool attempts to get the "root" package ID that the `cargo metadata` call was invoked against, which will be `None` for a workspace.

## Solution

In this PR, we've simply tweaked the code to handle either case. When there is a root package present, the logic stays the same. When there isn't, we run the same logic against _every_ package that got resolved in the dependency graph... basically gathering the sum of all dependencies in all workspace members.