### PR TITLE
chore: Drop dependency on `once_cell`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust_version: ["1.78", "stable"]
+        rust_version: ["1.80", "stable"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,7 +123,6 @@ dependencies = [
  "clap",
  "csv",
  "hex",
- "once_cell",
  "regex",
  "serde",
  "serde_json",
@@ -341,12 +340,6 @@ name = "memchr"
 version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
-
-[[package]]
-name = "once_cell"
-version = "1.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde51589ab56b20a6f686b2c68f7a0bd6add753d697abf720d63f8db3ab7b1ad"
 
 [[package]]
 name = "percent-encoding"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 authors = ["Datadog, Inc."]
 categories = ["command-line-utilities", "development-tools"]
 keywords = ["datadog", "license", "3rdparty"]
-rust-version = "1.78"
+rust-version = "1.80"
 
 [profile.release]
 strip = true
@@ -21,7 +21,6 @@ cargo_metadata = "0.19"
 clap = { version = "4.5.32", default-features = false, features = ["derive", "std", "help"] }
 csv = "1.3.1"
 hex = "0.4.3"
-once_cell = "1.21.0"
 regex = "1.11.1"
 serde = "1.0"
 serde_json = "1.0"

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -30,7 +30,6 @@ indexmap,https://github.com/indexmap-rs/indexmap,Apache-2.0 OR MIT,The indexmap 
 itoa,https://github.com/dtolnay/itoa,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 litemap,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers
 memchr,https://github.com/BurntSushi/memchr,Unlicense OR MIT,"Andrew Gallant <jamslam@gmail.com>, bluss"
-once_cell,https://github.com/matklad/once_cell,MIT OR Apache-2.0,Aleksey Kladov <aleksey.kladov@gmail.com>
 proc-macro2,https://github.com/dtolnay/proc-macro2,MIT OR Apache-2.0,"David Tolnay <dtolnay@gmail.com>, Alex Crichton <alex@alexcrichton.com>"
 quote,https://github.com/dtolnay/quote,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 regex,https://github.com/rust-lang/regex,MIT OR Apache-2.0,"The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,6 @@
+disallowed-types = [
+    { path = "once_cell::sync::OnceCell", reason = "Use `std::sync::OnceLock` instead." },
+    { path = "once_cell::unsync::OnceCell", reason = "Use `std::cell::OnceCell` instead." },
+    { path = "once_cell::sync::Lazy", reason = "Use `std::sync::LazyLock` instead." },
+    { path = "once_cell::unsync::Lazy", reason = "Use `std::sync::LazyCell` instead." },
+]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,13 +5,13 @@ use std::fs::{self, File};
 use std::io::{self, ErrorKind, Write};
 use std::mem::take;
 use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
 
 use anyhow::{bail, Context, Result};
 use cargo_metadata::{
     DepKindInfo, DependencyKind, MetadataCommand, Node, Package, PackageId, Resolve,
 };
 use clap::{Parser, Subcommand};
-use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -44,7 +44,7 @@ const COPYRIGHT_LOCATIONS: [&str; 17] = [
 ];
 
 // General match for anything that looks like a copyright declaration
-static RE_COPYRIGHT: Lazy<Regex> = Lazy::new(|| {
+static RE_COPYRIGHT: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"(?i)copyright\s+(?:©|\(c\)\s+)?(?:(?:[0-9 ,-]|present)+\s+)?(?:by\s+)?.*$")
         .unwrap()
 });
@@ -53,7 +53,7 @@ static RE_COPYRIGHT: Lazy<Regex> = Lazy::new(|| {
 // boilerplate license files.
 //
 // These match at the beginning of the copyright (the result of COPYRIGHT_RE).
-static RE_COPYRIGHT_IGNORE: Lazy<Regex> = Lazy::new(|| {
+static RE_COPYRIGHT_IGNORE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
     r"(?i)^(copyright(:? and license)?$|copyright (:?holder|owner|notice|license|statement)|Copyright & License -|copyright .yyyy. .name of copyright owner)").unwrap()
 });


### PR DESCRIPTION
This dependency can now be replaced by `std::sync::OnceLock`. This change bumps the MSRV to 1.80.