### PR TITLE
chore(ci): Add a single all-versions status check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ env:
   PROFILE: debug
 
 jobs:
-  test_versions:
+  test-versions:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -49,6 +49,18 @@ jobs:
         with:
           command: run
           args: -- check
+
+  test-all-versions:
+    runs-on: ubuntu-latest
+    needs: test-versions
+    if: always()
+    steps:
+      - name: All versions work
+        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        run: exit 0
+      - name: Some version failed
+        if: ${{ (contains(needs.*.result, 'failure')) }}
+        run: exit 1
 
   check-format:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This will be used to set up branch protection to work across all versions instead of having to configure each version.