### PR TITLE
fix: replace invalid team observability-pipelines-worker with observability-pipelines in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @DataDog/observability-pipelines-worker
+* @DataDog/observability-pipelines-worker-admin

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @DataDog/observability-pipelines-worker-admin
+* @DataDog/observability-pipelines


### PR DESCRIPTION
Replaces `@DataDog/observability-pipelines-worker` (no members) with `@DataDog/observability-pipelines`.

Jira: https://datadoghq.atlassian.net/browse/SCMGMT-681