### PR TITLE
feat: add cargo-binstall support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,93 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]*'
+
+permissions: {}
+
+jobs:
+  create-release:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+    steps:
+      - name: Create draft release
+        run: |
+          gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1 || \
+            gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --generate-notes --draft
+
+  build:
+    needs: create-release
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+          - os: macos-15
+            target: aarch64-apple-darwin
+          - os: windows-2025
+            target: x86_64-pc-windows-msvc
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.2.2
+
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
+        with:
+          profile: minimal
+          toolchain: stable
+          target: ${{ matrix.target }}
+          override: true
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.0.0
+
+      - name: Build
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
+        with:
+          command: build
+          args: --release --target ${{ matrix.target }}
+
+      - name: Package and upload (Unix)
+        if: runner.os != 'Windows'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          ARCHIVE="dd-rust-license-tool-${VERSION}-${{ matrix.target }}.tar.gz"
+          tar -czf "${ARCHIVE}" -C "target/${{ matrix.target }}/release" dd-rust-license-tool
+          gh release upload "$GITHUB_REF_NAME" "${ARCHIVE}" --clobber
+
+      - name: Package and upload (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          $Version = $env:GITHUB_REF_NAME -replace '^v', ''
+          $Archive = "dd-rust-license-tool-${Version}-${{ matrix.target }}.zip"
+          Compress-Archive -Path "target/${{ matrix.target }}/release/dd-rust-license-tool.exe" -DestinationPath $Archive
+          gh release upload $env:GITHUB_REF_NAME $Archive --clobber
+
+  publish-release:
+    needs: build
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+    steps:
+      - name: Publish release
+        run: gh release edit "$GITHUB_REF_NAME" --draft=false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Test Suite
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   merge_group:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,14 @@ categories = ["command-line-utilities", "development-tools"]
 keywords = ["datadog", "license", "3rdparty"]
 rust-version = "1.82"
 
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ version }-{ target }.tar.gz"
+pkg-fmt = "tgz"
+
+[package.metadata.binstall.overrides.'cfg(target_os = "windows")']
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ version }-{ target }.zip"
+pkg-fmt = "zip"
+
 [profile.release]
 strip = true
 

--- a/publish.sh
+++ b/publish.sh
@@ -44,4 +44,24 @@ read
 
 git tag v$version
 git push origin v$version
+
+echo "Waiting for release workflow to start (timeout: 10m)..."
+run_id=""
+deadline=$(( $(date +%s) + 600 ))
+while [ -z "$run_id" ]; do
+  if [ "$(date +%s)" -ge "$deadline" ]; then
+    echo "Error: release workflow did not start within 10 minutes."
+    exit 1
+  fi
+  sleep 5
+  run_id=$(gh run list --workflow=release.yml --branch="v$version" \
+    --json databaseId --jq '.[0].databaseId' 2>/dev/null || true)
+done
+
+echo "Release workflow started (run $run_id). Waiting for it to finish..."
+gh run watch "$run_id" --exit-status
+echo "Release workflow completed successfully."
+
+echo "Publishing to crates.io..."
 cargo publish
+echo "Done. Version $version published."


### PR DESCRIPTION
## Summary

- Adds `[package.metadata.binstall]` to `Cargo.toml` so `cargo binstall dd-rust-license-tool` resolves pre-built binaries from GitHub Releases
- Adds `.github/workflows/release.yml` triggered on `v*` tags (pushed by `publish.sh`): builds for `x86_64-linux`, `aarch64-linux` (native ARM runner), `aarch64-macos`, and `x86_64-windows`; creates a draft release, uploads all assets, then publishes atomically
- Adds `permissions: contents: read` to `test.yml` to satisfy OSSF Scorecard Token-Permissions check